### PR TITLE
added focus in select function for IE

### DIFF
--- a/mention/plugin.js
+++ b/mention/plugin.js
@@ -284,6 +284,7 @@
         },
 
         select: function (item) {
+            this.editor.focus();
             var selection = this.editor.dom.select('span#autocomplete')[0];
             this.editor.dom.remove(selection);
             this.editor.execCommand('mceInsertContent', false, this.insert(item) + '&nbsp;');


### PR DESCRIPTION
in ie9 and probably (ie10) when you click on an option in the pulldown menu the focus of the editor is lost and the selected option can not be added to the tinymce editor. This single line fixes this issue.
