### PR TITLE
Insert function can use a different value than the queryBy field.

### DIFF
--- a/mention/plugin.js
+++ b/mention/plugin.js
@@ -40,6 +40,8 @@
             items: 10
         }, options);
 
+        this.options.insertFrom = this.options.insertFrom || this.options.queryBy;
+
         this.matcher = this.options.matcher || this.matcher;
         this.renderDropdown = this.options.renderDropdown || this.renderDropdown;
         this.render = this.options.render || this.render;
@@ -313,7 +315,7 @@
         },
 
         insert: function (item) {
-            return '<span>' + item[this.options.queryBy] + '</span>&nbsp;';
+            return '<span>' + item[this.options.insertFrom] + '</span>&nbsp;';
         },
 
         cleanUp: function (rollback) {


### PR DESCRIPTION
I was using the plugin to display variable names to authors of text templates. 

 For instance:
```
"source":[
  {"name":"{{user:first_name}}"},
  {"name":"{{user:last_name}}"}
]
```
This works well enough for authoring a template, the author types { the variables are shown and replaced using the mentions plugin.  👍 

When the template is used, I want the same functionality, but instead of inserting `{{user:first_name}}` I want it to insert the user's actual name, `John`.    Instead of writing my own insert function, I added an optional value field to the source which gets used on insert:

```
insertFrom: 'value',
"source":[
  {"name":"{{user:first_name}}", "value": "John"},
  {"name":"{{user:last_name}}", "value": "John"}
]
```

Now when the insert is performed on a match of `{{user:first_name}}`, `John` gets insterted instead.

