### PR TITLE
Fix issue with non breaking space after delimiter

### DIFF
--- a/mention/plugin.js
+++ b/mention/plugin.js
@@ -69,7 +69,11 @@
 
             this.editor.execCommand('mceInsertContent', false, rawHtml);
             this.editor.focus();
-            this.editor.selection.select(this.editor.selection.dom.select('span#autocomplete-searchtext span')[0]);
+            this.editor.selection.select(
+              this.editor.selection.dom.select(
+                'span#autocomplete-searchtext span#autocomplete-delimiter'
+              )[0]
+            );
             this.editor.selection.collapse(0);
         },
 


### PR DESCRIPTION
Autocomplete can jump to the beginning of a node if there's a non breaking space after the delimiter when typing:

TinyMCE content:
```html
<p>Hello my name is&nbsp;!</p>
```

If you were to type
```html
<p>Hello my name is @&nbsp;!</p>
```

The autocomplete would fire and your cursor would select the beginning of the paragraph. The solution is just to reference the delimiter id when reselecting