### PR TITLE
Fixed bug where last highlighted item was being added

### DIFF
--- a/mention/plugin.js
+++ b/mention/plugin.js
@@ -271,6 +271,7 @@
                 this.$dropdown.html(result.join('')).show();
             } else {
                 this.$dropdown.hide();
+                this.$dropdown.find('li').removeClass('active');
             }
         },
 


### PR DESCRIPTION
Found and fixed a small bug.

Steps to reproduce:
1. Trigger the mention list
2. Highlight any item using the directional arrows
3. Continue typing until no items match your query so the list is no longer showing
4. Press the Enter Key
5. The last highlighted item will be added

Expected Result:
Pressing enter should leave the text as is and exit selection

I added a line of code in plugin.js that when the list is being removed that the active class it also removed from the item. 